### PR TITLE
Safer way to parse `year` when seeding

### DIFF
--- a/db/seeds/seed_movies.jl
+++ b/db/seeds/seed_movies.jl
@@ -3,7 +3,6 @@ using CSV
 
 Base.convert(::Type{String}, _::Missing) = ""
 Base.convert(::Type{Int}, _::Missing) = 0
-Base.convert(::Type{Int}, s::String) = parse(Int, s)
 
 function seed()
   for row in CSV.Rows(joinpath(@__DIR__, "netflix_titles.csv"), limit = 1_000)
@@ -14,7 +13,7 @@ function seed()
     m.directors = row.director
     m.actors = row.cast
     m.country = row.country
-    m.year = row.release_year
+    m.year = parse(Int, row.release_year)
     m.rating = row.rating
     m.categories = row.listed_in
     m.description = row.description


### PR DESCRIPTION
After encountering an error with the previous method:

```
ERROR: MethodError: Cannot `convert` an object of type PosLenString to an object of type Int64
```

I found this to be a safer, more effective way to import that data.